### PR TITLE
hide and show the cursor

### DIFF
--- a/src/DiffConsoleOutput.php
+++ b/src/DiffConsoleOutput.php
@@ -202,7 +202,7 @@ class DiffConsoleOutput implements OutputInterface
             }
         }
 
-        return $buffer;
+        return $this->terminal->hideCursor() . $buffer . $this->terminal->showCursor();
     }
 
     /**

--- a/src/Terminal/ANSI.php
+++ b/src/Terminal/ANSI.php
@@ -31,7 +31,10 @@ class ANSI implements CursorInterface
     const CODE_ERASE_UP               = '[1J';
     const CODE_ERASE_SCREEN           = '[2J';
 
-    const REGEX_ANSI       = "/(?:\r|\e(?:\\[[0-9;]*[HfABCDKJcnRsurgim]|\\[=\\[[0-9]{1,2}[hl]|[c\\(\\)78DMH]))/";
+    const CODE_HIDE_CURSOR = '[?25l';
+    const CODE_SHOW_CURSOR = '[?25h';
+
+    const REGEX_ANSI       = "/(?:\r|\e(?:\\[[0-9;]*[HfABCDKJcnRsurgim]|\\[(?:=|\?)\\[[0-9]{1,2}[hl]|[c\\(\\)78DMH]))/";
     const REGEX_FORMAT     = "/\e\\[((?:[0-9][0-9;]*|))m/";
     const REGEX_STYLE_ITEM = '/\b(?:(?:([34]8);(?:2;\d{1,3};\d{1,3};\d{1,3}|5;\d{1,3}))|(\d+)(?<!38|48))\b/';
     const REGEX_FIRST_KEY  = '/^(\d+)/';
@@ -199,6 +202,22 @@ class ANSI implements CursorInterface
     public function eraseScreen()
     {
         return static::ESCAPE . static::CODE_ERASE_SCREEN;
+    }
+
+    /**
+     * @return string
+     */
+    public function hideCursor()
+    {
+        return static::ESCAPE . static::CODE_HIDE_CURSOR;
+    }
+
+    /**
+     * @return string
+     */
+    public function showCursor()
+    {
+        return static::ESCAPE . static::CODE_SHOW_CURSOR;
     }
 
     /**

--- a/src/Terminal/CursorInterface.php
+++ b/src/Terminal/CursorInterface.php
@@ -114,4 +114,14 @@ interface CursorInterface
      * @return string
      */
     public function eraseScreen();
+
+    /**
+     * @return string
+     */
+    public function hideCursor();
+
+    /**
+     * @return string
+     */
+    public function showCursor();
 }

--- a/src/Terminal/Terminal.php
+++ b/src/Terminal/Terminal.php
@@ -160,6 +160,22 @@ class Terminal implements TerminalInterface
     }
 
     /**
+     * @return string
+     */
+    public function hideCursor()
+    {
+        return $this->cursor->hideCursor();
+    }
+
+    /**
+     * @return string
+     */
+    public function showCursor()
+    {
+        return $this->cursor->showCursor();
+    }
+
+    /**
      * Filter takes a string with Cursor movements and filters them out
      *
      * @param string $string

--- a/tests/unit/DiffConsoleOutputTest.php
+++ b/tests/unit/DiffConsoleOutputTest.php
@@ -168,7 +168,7 @@ class DiffConsoleOutputTest extends TestCase
         $this->console->reWrite(['first', 'second']);
 
         $this->output->shouldReceive('write')
-                     ->with("\e[1A\r\e[5C\e[K thing\n\r", false, static::DEFAULT_OPTIONS)
+                     ->with("\e[?25l\e[1A\r\e[5C\e[K thing\n\r\e[?25h", false, static::DEFAULT_OPTIONS)
                      ->once();
         $this->console->reWrite(['first thing', 'second']);
 
@@ -192,14 +192,14 @@ class DiffConsoleOutputTest extends TestCase
         $this->replacements['<info>first</info> thing'] = 'INFO[first] thing';
 
         $this->output->shouldReceive('write')
-                     ->with("\e[1A\r\e[11C\e[K thing\n\r", false, static::DEFAULT_OPTIONS)
+                     ->with("\e[?25l\e[1A\r\e[11C\e[K thing\n\r\e[?25h", false, static::DEFAULT_OPTIONS)
                      ->once();
         $this->console->reWrite(['<info>first</info> thing', '<error>second</error>']);
 
         $this->replacements['<info>first thing</info>'] = 'INFO[first thing]';
 
         $this->output->shouldReceive('write')
-                     ->with("\e[1A\r\e[10C\e[K thing]\n\r", false, static::DEFAULT_OPTIONS)
+                     ->with("\e[?25l\e[1A\r\e[10C\e[K thing]\n\r\e[?25h", false, static::DEFAULT_OPTIONS)
                      ->once();
         $this->console->reWrite(['<info>first thing</info>', '<error>second</error>']);
 
@@ -218,7 +218,7 @@ class DiffConsoleOutputTest extends TestCase
         $this->console->reWrite(['first', 'second'], true);
 
         $this->output->shouldReceive('write')
-                     ->with("\e[2A\r\e[5C\e[K thing\n\r", true, static::DEFAULT_OPTIONS)
+                     ->with("\e[?25l\e[2A\r\e[5C\e[K thing\n\r\e[?25h", true, static::DEFAULT_OPTIONS)
                      ->once();
         $this->console->reWrite(['first thing', 'second'], true);
 
@@ -237,7 +237,7 @@ class DiffConsoleOutputTest extends TestCase
         $this->console->reWrite(['first', 'second', 'third', 'fourth']);
 
         $this->output->shouldReceive('write')
-                     ->with("\e[3A\r\e[Knew\n\r\n\r\n\r", false, static::DEFAULT_OPTIONS)
+                     ->with("\e[?25l\e[3A\r\e[Knew\n\r\n\r\n\r\e[?25h", false, static::DEFAULT_OPTIONS)
                      ->once();
         $this->console->reWrite(['new', 'second', 'third', 'fourth']);
 
@@ -266,7 +266,7 @@ class DiffConsoleOutputTest extends TestCase
                       ->andReturn(['123cake   ', '12345']);
 
         $this->output->shouldReceive('write')
-                     ->with("\e[1A\r\e[3C\e[Kcake   \n\r", false, static::DEFAULT_OPTIONS)
+                     ->with("\e[?25l\e[1A\r\e[3C\e[Kcake   \n\r\e[?25h", false, static::DEFAULT_OPTIONS)
                      ->once();
         $this->console->reWrite(['123cake   12345']);
     }
@@ -291,7 +291,7 @@ class DiffConsoleOutputTest extends TestCase
                       ->once()
                       ->andReturn(['1234567890', '12345', '1234567890', '12345']);
         $this->output->shouldReceive('write')
-                     ->with("\e[1A\r\n\r\e[5C\e[K\n\r\e[K1234567890\n\r\e[K12345", false, static::DEFAULT_OPTIONS)
+                     ->with("\e[?25l\e[1A\r\n\r\e[5C\e[K\n\r\e[K1234567890\n\r\e[K12345\e[?25h", false, static::DEFAULT_OPTIONS)
                      ->once();
         $this->console->reWrite(['123456789012345', '123456789012345']);
     }
@@ -320,7 +320,7 @@ class DiffConsoleOutputTest extends TestCase
                       ->andReturn(['123cake   ']);
 
         $this->output->shouldReceive('write')
-                     ->with("\r\e[3C\e[Kcake   ", false, static::DEFAULT_OPTIONS)
+                     ->with("\e[?25l\r\e[3C\e[Kcake   \e[?25h", false, static::DEFAULT_OPTIONS)
                      ->once();
         $this->console->reWrite(['123cake   12345']);
     }
@@ -338,7 +338,7 @@ class DiffConsoleOutputTest extends TestCase
 
         $this->output->shouldReceive('write')
                      ->with(
-                         "\e[4A\r\e[Ksecond\n\r\e[Kthird\n\r\e[Kfourth\n\r\e[1C\e[Kifth\n\r\e[Ksixth",
+                         "\e[?25l\e[4A\r\e[Ksecond\n\r\e[Kthird\n\r\e[Kfourth\n\r\e[1C\e[Kifth\n\r\e[Ksixth\e[?25h",
                          false,
                          static::DEFAULT_OPTIONS
                      )
@@ -359,7 +359,7 @@ class DiffConsoleOutputTest extends TestCase
 
         $this->output->shouldReceive('write')
                      ->with(
-                         "\e[5A\r\e[Ksecond\n\r\e[Kthird\n\r\e[Kfourth\n\r\e[1C\e[Kifth\n\r\e[Ksixth",
+                         "\e[?25l\e[5A\r\e[Ksecond\n\r\e[Kthird\n\r\e[Kfourth\n\r\e[1C\e[Kifth\n\r\e[Ksixth\e[?25h",
                          true,
                          static::DEFAULT_OPTIONS
                      )

--- a/tests/unit/Terminal/ANSITest.php
+++ b/tests/unit/Terminal/ANSITest.php
@@ -89,6 +89,16 @@ class ANSITest extends TestCase
         $this->assertEquals("\e[2J", $this->cursor->eraseScreen());
     }
 
+    public function testShowCursor()
+    {
+        $this->assertEquals("\e[?25h", $this->cursor->showCursor());
+    }
+
+    public function testHideCursor()
+    {
+        $this->assertEquals("\e[?25l", $this->cursor->hideCursor());
+    }
+
     /**
      * @dataProvider filterData
      *


### PR DESCRIPTION
- When writing an update, hide the cursor at the beginning, then show it at the end. Reduces the flickering movement of the cursor around the screen.