### PR TITLE
Support PHP 8.0–8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4']
-        dependencies: [highest, lowest]
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        dependencies: [highest]
+        include:
+          - php: '7.4'
+            dependencies: lowest
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
           php-version: ${{ matrix.php }}
           tools: composer:v2
 
+      - name: Align composer platform.php with matrix PHP version
+        run: composer config platform.php ${{ matrix.php }}
+
       - name: Install dependencies
         uses: ramsey/composer-install@v4
         with:

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^7.4",
+        "php": "^7.4 || ^8.0",
         "symfony/console": "^3.4 | ^4.0 | ^5.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ad3c92c419ec035c3134e447270994bb",
+    "content-hash": "45bd62a296a29299ed7ec69b6e2332f7",
     "packages": [
         {
             "name": "psr/container",
@@ -2951,7 +2951,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4"
+        "php": "^7.4 || ^8.0"
     },
     "platform-dev": {},
     "platform-overrides": {

--- a/src/Diff/ConsoleDiff.php
+++ b/src/Diff/ConsoleDiff.php
@@ -28,7 +28,7 @@ class ConsoleDiff extends FirstDiff
      *
      * @param CursorInterface|null $cursor The cursor used to move around the screen
      */
-    public function __construct(CursorInterface $cursor = null)
+    public function __construct(?CursorInterface $cursor = null)
     {
         $this->cursor = $cursor ?: new ANSI();
     }

--- a/src/DiffConsoleOutput.php
+++ b/src/DiffConsoleOutput.php
@@ -49,8 +49,8 @@ class DiffConsoleOutput implements OutputInterface
      */
     public function __construct(
         OutputInterface $output,
-        TerminalInterface $terminal = null,
-        Wrapper $wrapper = null
+        ?TerminalInterface $terminal = null,
+        ?Wrapper $wrapper = null
     ) {
         $this->output = $output;
         $this->terminal = $terminal ?: new Terminal();

--- a/src/Terminal/Terminal.php
+++ b/src/Terminal/Terminal.php
@@ -26,7 +26,7 @@ class Terminal implements TerminalInterface
      * @param CursorInterface|null $cursor
      * @param DimensionsInterface  $dimensions
      */
-    public function __construct(CursorInterface $cursor = null, DimensionsInterface $dimensions = null)
+    public function __construct(?CursorInterface $cursor = null, ?DimensionsInterface $dimensions = null)
     {
         $this->cursor = $cursor ?: new ANSI();
         $this->dimensions = $dimensions ?: new TerminalDimensions();


### PR DESCRIPTION
## Summary

Widens the PHP requirement from `^7.4` to `^7.4 || ^8.0` so the library can be installed on PHP 8.0 through 8.5.

## Changes

| File(s) | Change | Why |
|---|---|---|
| `composer.json` | `php`: `^7.4` → `^7.4 \|\| ^8.0` | Allow installs on PHP 8.x |
| `src/Terminal/Terminal.php`, `src/DiffConsoleOutput.php`, `src/Diff/ConsoleDiff.php` | Added explicit `?` to nullable constructor parameters (`?T $param = null` instead of `T $param = null`) | PHP 8.4 deprecates implicit-nullable parameters. Forward-compatible with PHP 7.4 |
| `.github/workflows/ci.yml` | Matrix expanded: `highest` runs on PHP 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5; `lowest` stays pinned to PHP 7.4 only | The floor of each dependency lives at PHP 7.4 (e.g. `symfony/console 3.4` and `mockery 1.3` don't run on PHP 8.x). Running `--prefer-lowest` on PHP 8 would happily install those — composer doesn't reject them since their composer.json has no upper PHP bound — but they'd fail at runtime. Restricting `lowest` to 7.4 tests what we actually care about |
| `composer.lock` | Regenerated against the new constraint | Pick up the wider PHP range |

## Verification

Verified locally on PHP 7.4 (Docker `graze/php-alpine:7.4-test`) and PHP 8.5 (host): `phpcs` clean, **112 PHPUnit tests pass** under both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)