### PR TITLE
Makefile: use phpcs.xml standard explicitly, expand test-matrix to 8.0-8.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,10 @@ test: ## Run the unit and integration testsuites.
 test: lint test-unit
 
 lint: ## Run phpcs against the code.
-	${DOCKER_RUN} vendor/bin/phpcs -p --warning-severity=0 src/ tests/
+	${DOCKER_RUN} vendor/bin/phpcs --standard=./phpcs.xml -p --warning-severity=0 src/ tests/
 
 lint-fix: ## Run phpcsf and fix possible lint errors.
-	${DOCKER_RUN} vendor/bin/phpcbf -p src/ tests/
+	${DOCKER_RUN} vendor/bin/phpcbf --standard=./phpcs.xml -p src/ tests/
 
 test-unit: ## Run the unit testsuite.
 	${DOCKER_RUN} vendor/bin/phpunit --testsuite unit
@@ -63,6 +63,12 @@ test-matrix-lowest: ## Test all version, with the lowest version
 
 test-matrix: ## Run the unit tests against multiple targets.
 	${MAKE} PHP_VER="7.4" build-update test
+	${MAKE} PHP_VER="8.0" build-update test
+	${MAKE} PHP_VER="8.1" build-update test
+	${MAKE} PHP_VER="8.2" build-update test
+	${MAKE} PHP_VER="8.3" build-update test
+	${MAKE} PHP_VER="8.4" build-update test
+	${MAKE} PHP_VER="8.5" build-update test
 
 test-coverage: ## Run all tests and output coverage to the console.
 	${DOCKER_RUN} phpdbg7 -qrr vendor/bin/phpunit --coverage-text


### PR DESCRIPTION
## Summary

- **`lint` / `lint-fix`** pass `--standard=./phpcs.xml` to phpcs/phpcbf so local lint explicitly uses the repo ruleset and matches CI.
- **`test-matrix`** expanded from just `7.4` to **7.4 + 8.0, 8.1, 8.2, 8.3, 8.4, 8.5**. `graze/php-alpine` publishes `-test` tags for all of these, so `make test-matrix` runs the full matrix locally.

(`PHP_VER` already defaults to `7.4` here, so no change was needed there.)

## Verification

- `make test` (default PHP 7.4) → phpcs clean (19/19), PHPUnit 9.6.34 on PHP 7.4.26: **112 tests / 162 assertions, OK.**
- `make PHP_VER=8.5 test` → phpcs clean, PHPUnit 9.6.34 on PHP 8.5.6: **112 tests / 162 assertions, OK.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)